### PR TITLE
fix: apply Inter font-family by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,9 @@
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Web site created using create-react-app" />
     <link rel="manifest" href="/manifest.json" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
     <title>Sumé LMS</title>
   </head>
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ const router = createBrowserRouter(routes);
 
 const App: React.FC = () => {
   return (
-    <div className="flex flex-col text-gray-800 bg-white font-inter dark:bg-zinc-100 dark:text-gray-900">
+    <div className="flex flex-col text-gray-800 bg-white dark:bg-zinc-100 dark:text-gray-900">
       <RouterProvider router={router} />
     </div>
   );

--- a/src/assets/css/tailwind.css
+++ b/src/assets/css/tailwind.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+    html {
+      font-family: Inter, system-ui, sans-serif;
+    }
+  }


### PR DESCRIPTION
### Description

Updates font-family using Inter as default

### Issue

[Default font-family #186 ](https://github.com/sumelms/frontend/issues/186)

### Steps to reproduce

Steps to reproduce the behavior:

1. Go to Home
2. Inspect HTML elements (F12)
3. Select a text to Inspect
4. Check font-family
5. Go to [Figma](https://www.figma.com/file/GnUOWeEr9Pf4b53uW5zc2z/Sum%C3%A9-LMS-UI?type=design&node-id=137-20015&mode=design&t=Rk6BTOjUSaIi2PXq-4) 
6. Check font-family

### Screenshots

[Figma UI / UX](https://www.figma.com/file/GnUOWeEr9Pf4b53uW5zc2z/Sum%C3%A9-LMS-UI?type=design&node-id=51%3A14616&mode=design&t=Rk6BTOjUSaIi2PXq-1)
![Screenshot 2023-09-11 at 19 17 47](https://github.com/sumelms/frontend/assets/97555693/12d15155-f861-48b4-bf1c-2f9614ab666e)

Now X Before
![Screenshot 2023-09-11 at 19 18 13](https://github.com/sumelms/frontend/assets/97555693/e0827a94-b7f2-4d0f-b51b-da5318407c02)

### Additional context

Check [TailwindCSS font-family recommendations](https://tailwindcss.com/docs/font-family#customizing-the-default-font)